### PR TITLE
AT-1691: add truncate_table() to Pygyver

### DIFF
--- a/pygyver/etl/dw.py
+++ b/pygyver/etl/dw.py
@@ -647,8 +647,7 @@ class BigQueryExecutor:
 
     def copy_table(self, source_table_id, dest_table_id,
                    source_dataset_id=bq_default_dataset(), dest_dataset_id=bq_default_dataset(),
-                   source_project_id=bq_default_project(), write_disposition='WRITE_TRUNCATE',
-                   truncate=False):
+                   source_project_id=bq_default_project(), write_disposition='WRITE_TRUNCATE'):
         """
         Copy a BigQuery table
         
@@ -685,8 +684,6 @@ class BigQueryExecutor:
             dest_dataset_id,
             dest_table_id
         )
-        if truncate:
-            self.truncate_table(table_id=dest_table_id, dataset_id=dest_dataset_id)
 
     def count_rows(self, table_id, dataset_id=bq_default_dataset()):
         """

--- a/pygyver/etl/dw.py
+++ b/pygyver/etl/dw.py
@@ -710,12 +710,12 @@ class BigQueryExecutor:
         table = self.client.get_table(table_ref)
         return len(table.schema)
 
-    def count_duplicates(self, table_id, primary_key: set, dataset_id=bq_default_dataset()):
+    def count_duplicates(self, table_id, primary_key: list, dataset_id=bq_default_dataset()):
         """
         Count duplicate rows in primary key
 
         Arguments:
-        primary_key: a set of one or more column names, e.g. {'col1', 'col2'}
+        primary_key: a list of one or more column names, e.g. ['col1', 'col2']
 
         Returns:
         non-negative integer
@@ -737,12 +737,12 @@ class BigQueryExecutor:
         )
         return data['dup_total'].values[0]
 
-    def assert_unique(self, table_id, primary_key: set, dataset_id=bq_default_dataset(), ignore_error=False):
+    def assert_unique(self, table_id, primary_key: list, dataset_id=bq_default_dataset(), ignore_error=False):
         """
         Assert uniqueness of primary key in table
 
         Arguments:
-        primary_key: a set of one or more column names, e.g. {'col1', 'col2'}
+        primary_key: a list of one or more column names, e.g. ['col1', 'col2']
         ignore_error: boolean flag to prevent error being raised, useful for debugging
 
         Returns:

--- a/pygyver/etl/dw.py
+++ b/pygyver/etl/dw.py
@@ -227,7 +227,7 @@ class BigQueryExecutor:
                 )
             except exceptions.Conflict as error:
                 logging.error(error)
-                
+
     def create_table(self, table_id, dataset_id=bq_default_dataset(), sql=None, file=None,
                      write_disposition='WRITE_TRUNCATE', use_legacy_sql=False,
                      location='US', schema_path='',

--- a/pygyver/etl/dw.py
+++ b/pygyver/etl/dw.py
@@ -227,7 +227,7 @@ class BigQueryExecutor:
                 )
             except exceptions.Conflict as error:
                 logging.error(error)
-
+                
     def create_table(self, table_id, dataset_id=bq_default_dataset(), sql=None, file=None,
                      write_disposition='WRITE_TRUNCATE', use_legacy_sql=False,
                      location='US', schema_path='',
@@ -250,8 +250,7 @@ class BigQueryExecutor:
                 partition=partition
             )
             if write_disposition == "WRITE_TRUNCATE":
-                query = """DELETE FROM {}.{} WHERE 1=1""".format(dataset_id, table_id)
-                self.execute_sql(sql=query, dialect='standard')
+                self.truncate_table(dataset_id=dataset_id, table_id=table_id)
                 write_disposition = "WRITE_EMPTY"
         else:
             pass
@@ -626,9 +625,30 @@ class BigQueryExecutor:
         else:
             raise Exception("Please initiate %s.%s or pass the schema file", dataset_id, table_id)
     
+    def truncate_table(self, table_id, dataset_id=bq_default_dataset()):
+        """
+        Delete all records from table but preserve structure
+        e.g. schema, partitioning, clustering, description, labels, etc.
+        """
+        job_config = bigquery.QueryJobConfig()
+        job_config.destination = self.get_table_ref(dataset_id, table_id)
+        job_config.write_disposition = set_write_disposition("WRITE_TRUNCATE")
+        query_job = self.client.query(
+            query=f"SELECT * FROM `{dataset_id}.{table_id}` LIMIT 0",
+            job_config=job_config
+        )
+        query_job.result()
+        logging.info(
+            'Table %s:%s.%s has been truncated',
+            self.project_id,
+            dataset_id,
+            table_id
+        )
+
     def copy_table(self, source_table_id, dest_table_id,
                    source_dataset_id=bq_default_dataset(), dest_dataset_id=bq_default_dataset(),
-                   source_project_id=bq_default_project(), write_disposition='WRITE_TRUNCATE'):
+                   source_project_id=bq_default_project(), write_disposition='WRITE_TRUNCATE',
+                   truncate=False):
         """
         Copy a BigQuery table
         
@@ -665,7 +685,31 @@ class BigQueryExecutor:
             dest_dataset_id,
             dest_table_id
         )
+        if truncate:
+            self.truncate_table(table_id=dest_table_id, dataset_id=dest_dataset_id)
+
+    def count_rows(self, table_id, dataset_id=bq_default_dataset()):
+        """
+        Count rows in table
+        
+        Returns:
+        non-negative integer
+        """
+        table_ref = self.get_table_ref(dataset_id, table_id)
+        table = self.client.get_table(table_ref)
+        return table.num_rows
     
+    def count_columns(self, table_id, dataset_id=bq_default_dataset()):
+        """
+        Count columns in table
+        
+        Returns:
+        non-negative integer
+        """
+        table_ref = self.get_table_ref(dataset_id, table_id)
+        table = self.client.get_table(table_ref)
+        return len(table.schema)
+
     def count_duplicates(self, table_id, primary_key: set, dataset_id=bq_default_dataset()):
         """
         Count duplicate rows in primary key

--- a/tests/test_dw.py
+++ b/tests/test_dw.py
@@ -894,7 +894,7 @@ class BigQueryExecutorCheckDQ(unittest.TestCase):
             self.bq_client.count_duplicates(
                 dataset_id='test',
                 table_id='bq_check_dq',
-                primary_key={'col1'}
+                primary_key=['col1']
             ),
             1
         )
@@ -902,19 +902,19 @@ class BigQueryExecutorCheckDQ(unittest.TestCase):
             self.bq_client.assert_unique(
                 dataset_id='test',
                 table_id='bq_check_dq',
-                primary_key={'col1'}
+                primary_key=['col1']
             )
         with self.assertLogs(level='WARNING'):
             self.bq_client.assert_unique(
                 dataset_id='test',
                 table_id='bq_check_dq',
-                primary_key={'col1'},
-                ignore_error=True,
+                primary_key=['col1'],
+                ignore_error=True
             )
         self.bq_client.assert_unique(
             dataset_id='test',
             table_id='bq_check_dq',
-            primary_key={'col1', 'col2'}
+            primary_key=['col1', 'col2']
         )
 
 


### PR DESCRIPTION
**`truncate_table()`**
This function deletes all records from a table, but retains the structure.
Method is essentially similar to running `create_table()` with following arguments:
- `dataset_id = dataset_id`
- `table_id = table_id`
- `sql = "SELECT * FROM `dataset_id.table_id` LIMIT 0"`

Note: slight refactoring of `create_table()` to take advantage of the new function

**+ Also added 2 basic DQ checks -- `count_rows()` and `count_columns()`**
- When devising tests for `truncate_copy()`, it seemed trivial to add a couple of extra data quality checks to the library
- I added these next to the primary key checks, and renamed the test class to `BigQueryExecutorCheckDQ` to include them.


**+ Also a hotfix for the DQ checks**
- primary_key argument was previously a set, now changed to list
- set is arguably a more accurate type since order is irrelevant, but list is more consistent with data input from reading YAML etc. and is therefore preferred
- i have checked that there is currently no code dependent on this function